### PR TITLE
Fix code gen for repeated enum fields

### DIFF
--- a/template.go
+++ b/template.go
@@ -102,9 +102,7 @@ export class {{.Name}} implements {{.Interface}} {
 
   // {{.Field}} ({{.Name}})
   public get {{.Field}}(): {{. | fieldType}} {
-    {{if .IsEnum -}}
-      return (<any>{{. | fieldType}})[this._json.{{.Name}}!]
-    {{- else if .IsRepeated -}}
+    {{if .IsRepeated -}}
       return this._json.{{.Name}} || []
     {{- else -}}
       return this._json.{{.Name}}!
@@ -316,6 +314,17 @@ func objectToField(fv fieldValues) string {
 				fv.Name, upperCaseFirst(t),
 			)
 		}
+
+		if fv.IsEnum {
+			return fmt.Sprintf(strings.TrimSpace(`
+(m["%s"]! || []).map(v => {
+        return (<any>%s)[v];
+      })
+`),
+				fv.Name, fv.Type,
+			)
+		}
+
 		return fmt.Sprintf(strings.TrimSpace(`
 (m["%s"]! || []).map(v => {
         return %s.fromJSON(v);


### PR DESCRIPTION
Because of the order of checking `IsEnum` and `IsRepeated` in the
templates, fields that are enums *and* repeated were being generated
with invalid code.

- Simplify the getters to return the already decoded and typed object
  from the internal `_json` dict for all enums -> these are already
  converted from strings in `fromJSON`
- Add a case for repeated enums in `fromJSON` to iterate over the list
  of incoming strings and convert them to proper enum types